### PR TITLE
configurable intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ get metrics from cloudwatch.
   dimensions_name  [dimensions_name]
   dimensions_value [dimensions value]
   period           [period] (default: 60)
+  interval         [interval] (default: 60)
 </source>
 
 ```

--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -12,6 +12,7 @@ class Fluent::CloudwatchInput < Fluent::Input
   config_param :dimensions_name,   :string, :default => nil
   config_param :dimensions_value,  :string, :default => nil
   config_param :period,            :integer, :default => 60
+  config_param :interval,          :integer, :default => 60
 
 
    def initialize
@@ -42,7 +43,7 @@ class Fluent::CloudwatchInput < Fluent::Input
   private
   def watch
     while true
-      sleep 60
+      sleep @interval
       output
     end
   end


### PR DESCRIPTION
It would be nice to have the hard coded 60 second interval to be configurable, as the default e2 metrics (non-detailed) is only updated every 5 minutes and we could cut down on the number of un-necessary API requests which are charged.
