### PR TITLE
use the latest datapoint after sorting by timestamp

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -64,10 +64,11 @@ class Fluent::CloudwatchInput < Fluent::Input
       })
       unless statistics[:datapoints].empty?
         stat = @statistics.downcase.to_sym
-        data = statistics[:datapoints][0][stat]
+        datapoint = statistics[:datapoints].sort_by{|h| h[:timestamp]}.last
+        data = datapoint[stat]
 
         # unix time
-        catch_time = statistics[:datapoints][0][:timestamp].to_i
+        catch_time = datapoint[:timestamp].to_i
 
         # no output_data.to_json
         output_data = {m => data}


### PR DESCRIPTION
The array of datapoints returned by AWS is not sorted by default and the current implementation will give back mixed results when there are multiple datapoints involved.

This fixes the issue by sorting by timestamp and returning the latest datapoint.
