### PR TITLE
Extend time span for fetching data points.

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -66,7 +66,7 @@ class Fluent::CloudwatchInput < Fluent::Input
           :name  => @dimensions_name,
           :value => @dimensions_value,
         }],
-        :start_time  => (Time.now - @period*2).iso8601,
+        :start_time  => (Time.now - @period*5).iso8601,
         :end_time    => Time.now.iso8601,
         :period      => @period,
       })


### PR DESCRIPTION
Because sometimes can't  get Cloudwatch API's latest data after one or two minutes.
