### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -12,8 +12,8 @@ class Fluent::CloudwatchInput < Fluent::Input
   end
 
   config_param :tag,               :string
-  config_param :aws_key_id,        :string, :default => nil
-  config_param :aws_sec_key,       :string, :default => nil
+  config_param :aws_key_id,        :string, :default => nil, :secret => true
+  config_param :aws_sec_key,       :string, :default => nil, :secret => true
   config_param :cw_endpoint,       :string, :default => nil
 
   config_param :namespace,         :string, :default => nil


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
https://github.com/fluent/fluentd/blob/4e3a4ecb/ChangeLog#L34

This feature works as below:

```log
  <source>
    type cloudwatch
    tag cloudwatch
    aws_key_id xxxxxx
    aws_sec_key xxxxxx
    cw_endpoint ENDPOINT
  </source>
</ROOT>
```