### PR TITLE
Add development dependency test unit 3.1.0 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ rvm:
 gemfile:
   - Gemfile
   - Gemfile.fluentd.0.10
+
+matrix:
+  exclude:
+    - rvm: 2.2
+      gemfile: Gemfile.fluentd.0.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.5
+  - 2.1
 
 gemfile:
   - Gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
 
 gemfile:
   - Gemfile

--- a/fluent-plugin-cloudwatch.gemspec
+++ b/fluent-plugin-cloudwatch.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "fluentd", ">= 0.10.30"
   gem.add_dependency "aws-sdk", "~> 1.59.1"
   gem.add_development_dependency "rake", ">= 0.9.2"
+  gem.add_development_dependency "test-unit", ">= 3.1.0"
   gem.license = 'MIT'
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible API.