### PR TITLE
add config offset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Note: Billing requires the us-east-1 endpoint
 
 When config `delayed_start` is set true, plugin startup will be delayed in random seconds(0 ~ interval).
 
+## config: offset
+
+unit: seconds.
+
+flunet-plugin-cloudwatch gets metrics between now and `period` &times; 10 sec ago, and pick a latest value from that.
+
+But the latest metric is insufficient for `statistics Sum`.
+
+If `offset` is specified, fluent-plugin-cloudwatch gets metrics between `offset` sec ago and older.
+
 ## Contributing
 
 1. Fork it

--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -26,6 +26,7 @@ class Fluent::CloudwatchInput < Fluent::Input
   config_param :open_timeout,      :integer, :default => 10
   config_param :read_timeout,      :integer, :default => 30
   config_param :delayed_start,     :bool,    :default => false
+  config_param :offset,            :integer, :default => 0
 
   attr_accessor :dimensions
 
@@ -130,13 +131,14 @@ class Fluent::CloudwatchInput < Fluent::Input
 
   def output
     @metric_name.split(",").each {|m|
+      now = Time.now - @offset
       statistics = @cw.get_metric_statistics({
         :namespace   => @namespace,
         :metric_name => m,
         :statistics  => [@statistics],
         :dimensions  => @dimensions,
-        :start_time  => (Time.now - @period*10).iso8601,
-        :end_time    => Time.now.iso8601,
+        :start_time  => (now - @period*10).iso8601,
+        :end_time    => now.iso8601,
         :period      => @period,
       })
       unless statistics[:datapoints].empty?


### PR DESCRIPTION
A latest metric is insufficient for statistics Sum for some type of metrics. (e.g. CloudWatch RequestCount)