### PR TITLE
Added the emit_zero parameter

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -152,7 +152,8 @@ class Fluent::CloudwatchInput < Fluent::Input
         catch_time = datapoint[:timestamp].to_i
         router.emit(tag, catch_time, { name => data })
       elsif @emit_zero
-        router.emit(tag, now, {name => 0})
+        time = Fluent::Engine.now
+        router.emit(tag, time, {name => 0})
       else
         log.warn "cloudwatch: #{@namespace} #{@dimensions_name} #{@dimensions_value} #{name} #{s} datapoints is empty"
       end

--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -27,6 +27,7 @@ class Fluent::CloudwatchInput < Fluent::Input
   config_param :read_timeout,      :integer, :default => 30
   config_param :delayed_start,     :bool,    :default => false
   config_param :offset,            :integer, :default => 0
+  config_param :emit_zero,         :bool,    :default => false
 
   attr_accessor :dimensions
 
@@ -143,13 +144,15 @@ class Fluent::CloudwatchInput < Fluent::Input
         :end_time    => now.iso8601,
         :period      => @period,
       })
-      unless statistics[:datapoints].empty?
+      if not statistics[:datapoints].empty?
         datapoint = statistics[:datapoints].sort_by{|h| h[:timestamp]}.first
         data = datapoint[s.downcase.to_sym]
 
         # unix time
         catch_time = datapoint[:timestamp].to_i
         router.emit(tag, catch_time, { name => data })
+      elsif @emit_zero
+        router.emit(tag, now, {name => 0})
       else
         log.warn "cloudwatch: #{@namespace} #{@dimensions_name} #{@dimensions_value} #{name} #{s} datapoints is empty"
       end


### PR DESCRIPTION
I would like to have a parameter (I called it emit_zero, there is probably a better / prettier name :), to have the plugin emit "0" when no datapoints were found. Otherwise I get this error all the time:
```
2016-04-12 08:47:23 +0000 [warn]: cloudwatch: AWS/ELB LoadBalancerName MyLB HTTPCode_Backend_5XX Sum datapoints is empty
```
And actually it is _good_ that the 5XX count is ZERO :).

When this parameter is `true`, the plugin will just emit a zero when no datapoints were found. If it is `false` (the default value),  it will behave as it behaves now (generating that warning message).

Thanks!
Martin