### PR TITLE
Support CloudWatchLogs Metric Filter

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -49,7 +49,7 @@ class Fluent::CloudwatchInput < Fluent::Input
           :value => values.next,
         })
       end
-    else
+    elsif @dimensions_name || @dimensions_value
       @dimensions.push({
         :name => @dimensions_name,
         :value => @dimensions_value,

--- a/test/plugin/test_in_cloudwatch.rb
+++ b/test/plugin/test_in_cloudwatch.rb
@@ -116,4 +116,30 @@ class CloudwatchInputTest < Test::Unit::TestCase
     assert_equal true, d.instance.delayed_start
   end
 
+  ### for CloudWatchLogsMetricFilters
+  CONFIG_CWLOG_MF = %[
+    tag cloudwatch
+    aws_key_id test_key_id
+    aws_sec_key test_sec_key
+    cw_endpoint test_cloud_watch_endpoint
+    namespace LogMetrics
+    metric_name LogAccessCount,LogErrorCount
+  ]
+
+  def create_driver_cwlog_mf(conf = CONFIG_CWLOG_MF)
+     Fluent::Test::InputTestDriver.new(Fluent::CloudwatchInput).configure(conf)
+  end
+
+  def test_configure_cwlog_mf
+    d = create_driver_cwlog_mf
+    assert_equal 'cloudwatch', d.instance.tag
+    assert_equal 'test_key_id', d.instance.aws_key_id
+    assert_equal 'test_sec_key', d.instance.aws_sec_key
+    assert_equal 'test_cloud_watch_endpoint', d.instance.cw_endpoint
+    assert_equal 'LogMetrics', d.instance.namespace
+    assert_equal 'LogAccessCount,LogErrorCount', d.instance.metric_name
+    assert_nil d.instance.dimensions_name
+    assert_nil d.instance.dimensions_value
+    assert_equal [], d.instance.dimensions
+  end
 end


### PR DESCRIPTION
The metric created by [CloudWatch Logs metric filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/MonitoringLogData.html) has no dimensions.
So I change the code to be able to request get_metric_statistics api without exception when dimension_name and dimension_value is not specified.

```
      statistics = @cw.get_metric_statistics({
        :namespace   => @namespace,
        :metric_name => name,
        :statistics  => [s],
        :dimensions  => [], # => OK
#      :dimensions => [{name: nil, value: nil}] # => Error: <AWS::Core::OptionGrammar::FormatError: expected string value for key name of member 1 of option dimensions>
        :start_time  => (now - @period*10).iso8601,
        :end_time    => now.iso8601,
        :period      => @period,
      })
```