### PR TITLE
Fix compatibility with fluentd 0.14.x

### DIFF
--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 class Fluent::CloudwatchInput < Fluent::Input
   Fluent::Plugin.register_input("cloudwatch", self)
 


### PR DESCRIPTION
Getting this error with fluentd v0.14.13.

```
unexpected error error_class=NameError error="uninitialized constant Fluent::Input"
/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-cloudwatch-1.2.15/lib/fluent/plugin/in_cloudwatch.rb:1:in `<top (required)>'
```

According to https://github.com/repeatedly/fluent-plugin-beats/issues/1 , it seems to need `require 'fluent/input'` statement.
