### PR TITLE
Added custom `dimension_id` field which is outputted with datapoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+*.iml
+.idea/*

--- a/lib/fluent/plugin/in_cloudwatch.rb
+++ b/lib/fluent/plugin/in_cloudwatch.rb
@@ -16,6 +16,7 @@ class Fluent::CloudwatchInput < Fluent::Input
   end
 
   config_param :tag,               :string
+  config_param :dimension_id,      :string, :default => nil
   config_param :aws_key_id,        :string, :default => nil, :secret => true
   config_param :aws_sec_key,       :string, :default => nil, :secret => true
   config_param :cw_endpoint,       :string, :default => nil
@@ -164,9 +165,9 @@ class Fluent::CloudwatchInput < Fluent::Input
 
         # unix time
         catch_time = datapoint[:timestamp].to_i
-        router.emit(tag, catch_time, { name => data })
+        router.emit(tag, catch_time, { name => data, "dimension_id" => dimension_id })
       elsif @emit_zero
-        router.emit(tag, now.to_i, { name => 0 })
+        router.emit(tag, now.to_i, { name => 0, "dimension_id" => dimension_id })
       else
         log.warn "cloudwatch: #{@namespace} #{@dimensions_name} #{@dimensions_value} #{name} #{s} datapoints is empty"
       end


### PR DESCRIPTION
I wanted to be able to add some custom attributes to the outputted record as have others https://github.com/yunomu/fluent-plugin-cloudwatch/issues/20. This is a trivial implementation, but works for my needs, allowing `tag` to be generic e.g. cloudwatch_rds and `dimension_id` to be specific e.g. my-pgsql-instance-0123